### PR TITLE
Use a null object to avoid checks to @instance

### DIFF
--- a/lib/rails_multisite/connection_management/null_instance.rb
+++ b/lib/rails_multisite/connection_management/null_instance.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module RailsMultisite
+  class ConnectionManagement
+    class NullInstance
+      class << self
+        def clear_settings!; end
+        def config_filename; end
+        def default_connection_handler=(_connection_handler); end
+        def establish_connection(_opts); end
+        def reload; end
+
+        def all_dbs
+          [DEFAULT]
+        end
+
+        def connection_spec(_opts)
+          ConnectionSpecification.current
+        end
+
+        def current_db
+          DEFAULT
+        end
+
+        def each_connection(_opts = nil, &blk)
+          with_connection(&blk)
+        end
+
+        def has_db?(db)
+          db == DEFAULT
+        end
+
+        def host(env)
+          env["HTTP_HOST"]
+        end
+
+        def with_connection(db = DEFAULT, &blk)
+          connected = ActiveRecord::Base.connection_pool.connected?
+          result = blk.call(db)
+          ActiveRecord::Base.clear_active_connections! unless connected
+          result
+        end
+
+        def with_hostname(hostname, &blk)
+          blk.call(hostname)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In the `ConnectionManagement` class, a pattern we see a lot is the following one:
```ruby
if @instance
  # do something
else
  # do something else
end
```

This patch aims to simplify this a bit by introducing a null object (`NullInstance`) which will be returned when `@instance` is null. This way the rest of the code doesn’t care with which object it’s working and has just to call the expected methods on it.